### PR TITLE
fix(deps): clear remaining Dependabot alerts (minimatch, picomatch)

### DIFF
--- a/.rhino/package-lock.json
+++ b/.rhino/package-lock.json
@@ -6682,7 +6682,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7117,7 +7119,9 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14045,7 +14049,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.1.2",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -14335,7 +14341,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true
     },
     "pkg-dir": {


### PR DESCRIPTION
Bumps the two remaining flagged transitive build deps to patched versions:

- `minimatch` 3.1.2 → 3.1.5 — clears **GHSA-7r86-cg39-jmmj** (high)
- `picomatch` 2.3.1 → 2.3.2 — clears **GHSA-3v7f-55p6-f55p** (medium)

Both are `scope=development` (Rhino build toolchain only, never in the deployed app). Dependabot couldn't auto-path these, but every parent range already permits the patched version, so this is a **lockfile-only** `npm update minimatch picomatch` — no `package.json` change, no other dependencies touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)