### PR TITLE
fix(mixed-effects): correct sidebar namespacer typo (session$ns)

### DIFF
--- a/app/view/mixed_effects_demand_sidebar.R
+++ b/app/view/mixed_effects_demand_sidebar.R
@@ -308,7 +308,7 @@ sidebar_ui <- function(id) {
 #' @export
 sidebar_server <- function(id, data_reactive) {
   shiny$moduleServer(id, function(input, output, session) {
-    ns <- session$NS
+    ns <- session$ns
 
     # Create session-specific logger
     session_logger <- logging_utils$create_session_logger(session)

--- a/tests/testthat/test-mixed_effects_demand_sidebar.R
+++ b/tests/testthat/test-mixed_effects_demand_sidebar.R
@@ -1,0 +1,35 @@
+# Regression test for app/view/mixed_effects_demand_sidebar.R
+#
+# Telemetry signature c371dccc (`could not find function "ns"`, 4 occurrences).
+# `sidebar_server()` bound the module namespacer with `ns <- session$NS`, but a
+# Shiny session exposes the lowercase `session$ns`; `session$NS` is NULL. Because
+# R skips non-function bindings during function-call lookup, every `ns(...)` in
+# the server raised `could not find function "ns"`, breaking the exponentiated
+# Mixed-Effects Demand path (the k-value selector rendered by output$k_value_mixed).
+
+box::use(
+  shiny[reactive, testServer],
+  testthat[describe, expect_no_error, expect_true, it],
+)
+
+box::use(
+  app / view / mixed_effects_demand_sidebar,
+)
+
+describe("mixed_effects_demand_sidebar$sidebar_server()", {
+  it("renders the exponentiated k-value input without a namespacing error", {
+    testServer(
+      mixed_effects_demand_sidebar$sidebar_server,
+      args = list(data_reactive = reactive(NULL)),
+      {
+        # Selecting the exponentiated model reveals the k-value selectInput,
+        # whose inputId is built with ns("k_mixed"). With the `session$NS`
+        # typo this raised `could not find function "ns"`; the fix
+        # (`ns <- session$ns`) lets the output render cleanly.
+        session$setInputs(model_choice = "exponentiated")
+        expect_no_error(output$k_value_mixed)
+        expect_true(!is.null(output$k_value_mixed))
+      }
+    )
+  })
+})


### PR DESCRIPTION
## Summary
Fixes telemetry error signature **c371dccc** — `could not find function "ns"` (4 occurrences). In `app/view/mixed_effects_demand_sidebar.R`, `sidebar_server()` bound the module namespacer as `ns <- session$NS`. A Shiny session exposes the namespace function as lowercase `session$ns`; `session$NS` is `NULL`. Because R skips non-function bindings during function-call lookup, every `ns(...)` in the server raised `could not find function "ns"`, breaking the exponentiated Mixed-Effects Demand path (the k-value selector at `output$k_value_mixed`, built with `ns("k_mixed")`).

## Change
- **One-character fix:** `session$NS` → `session$ns` (`app/view/mixed_effects_demand_sidebar.R:311`).
- **New regression test** `tests/testthat/test-mixed_effects_demand_sidebar.R`: instantiates `sidebar_server` via `shiny::testServer`, sets `model_choice = "exponentiated"`, and asserts `output$k_value_mixed` renders without error. (First `testServer` test in the suite.)

## Base / provenance
- Branched from `origin/develop` @ **6c6c39e** (SHA-pinned).
- Source: shinybeez-analytics error investigation (2026-07-01), signature #7.

## Verification
- ✅ **Independent Codex review** (read-only, adversarial, over `git diff origin/develop...HEAD`): **APPROVE** — zero Blocking / Should-fix / Nice-to-have findings. Confirmed `session$ns` is the repo-wide convention (ripgrep) and that the test forces the failing `renderUI` path (`:326` → `ns("k_mixed")` `:329`).
- ⚠️ **Lint/tests were NOT run locally** — this machine has no restored renv library (empty project + global libraries; local R drifted 4.4 → 4.5.3), so `rhino::lint_r()` / `testthat` could not execute. **Executable verification is delegated to this PR's CI.** The new test file is lint-clean against `.lintr` (line length ≤ 120; longest line 84).
- Both author (Claude) and reviewer (Codex) confirmed the fix and that the test catches the bug by **static reasoning only** — neither executed R. CI is the first actual run.

## CI note
Requires the companion PR *"ci: run CI checks on pull requests into develop"* to be **merged to develop first** — otherwise this PR gets no automatic checks (base-branch `develop` currently has no `pull_request` trigger).

## Deploy / revert
Merging to `develop` auto-deploys **staging** (`ci-cd.yml`). Revert with `git revert ff37264`, or close without merging.
