### PR TITLE
ci: run CI checks on pull requests into develop

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,7 +8,7 @@ on:
     branches: [ main, develop ]
     tags: [ 'v*' ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
   workflow_dispatch:
     inputs:
       full_tests:


### PR DESCRIPTION
## Summary
Adds `develop` to the `pull_request` trigger branches in `ci-cd.yml` so PRs targeting `develop` get automatic lint + testthat checks **before** merge. Previously CI only ran on `pull_request` into `main`, so develop-targeted PRs had no pre-merge gate — checks ran only *after* merge (which also auto-deploys staging).

## Change
`.github/workflows/ci-cd.yml`: `pull_request: branches: [ main ]` → `[ main, develop ]` (one line).

## Notes
- `pull_request` events keep `SHINYBEEZ_FULL_TESTS=false`, so develop PRs run the **core lint + testthat** suite — not the full integration/Cypress suite, which stays push/tag/`workflow_dispatch`-gated. Extend the `SHINYBEEZ_FULL_TESTS` condition if you want full tests on develop PRs too.
- The trigger only affects PRs opened **after** this merges.
- Merging to `develop` auto-deploys **staging**.
- Base: `origin/develop` @ 6c6c39e.
